### PR TITLE
Downgrade go version to 1.20

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.x
+        go-version: 1.20.x
 
     - name: Checkout code
       uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.21.x
+          go-version: 1.20.x
 
       - name: Checkout Code
         uses: actions/checkout@v3

--- a/common.go
+++ b/common.go
@@ -15,7 +15,7 @@ func BytesToHash(b []byte) Hash {
 	var h Hash
 
 	size := len(b)
-	min := min(size, HashLength)
+	min := Min(size, HashLength)
 
 	copy(h[HashLength-min:], b[len(b)-min:])
 
@@ -46,4 +46,13 @@ func NewKeccakState() KeccakState {
 // EncodeToHex generates a hex string based on the byte representation, with the '0x' prefix
 func EncodeToHex(str []byte) string {
 	return "0x" + hex.EncodeToString(str)
+}
+
+// Min returns smaller number between provided two
+func Min(a, b int) int {
+	if a < b {
+		return a
+	}
+
+	return b
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Ethernal-Tech/merkle-tree
 
-go 1.21
+go 1.20
 
 require (
 	github.com/stretchr/testify v1.8.4


### PR DESCRIPTION
Thit PR includes downgrading go version from 1.21 to 1.20 so that it is compatible with older projects (such as Blade).